### PR TITLE
State Init überarbeitet

### DIFF
--- a/esp-client/lib/State/state.cpp
+++ b/esp-client/lib/State/state.cpp
@@ -1,5 +1,10 @@
 #include "state.h"
 
+void State::init()
+{
+	this->setupLEDs();
+	this->setState(States::INIT, true);
+}
 void State::setupLEDs()
 {
 	pinMode(R_LED_PIN, OUTPUT);

--- a/esp-client/lib/State/state.cpp
+++ b/esp-client/lib/State/state.cpp
@@ -125,7 +125,14 @@ void State::loop()
 
 void State::updateLEDs()
 {
-	if (this->isError())
+	if (this->isInit())
+	{
+		Serial.print("In Init");
+		ledcWrite(R_LEDC_CHANEL, LEDC_OFF_DUTY);
+		ledcWrite(B_LEDC_CHANEL, LEDC_ON_DUTY);
+		digitalWrite(G_LED_PIN, LOW);
+	}
+	else if (this->isError())
 	{
 		Serial.print("In Error");
 		ledcWrite(R_LEDC_CHANEL, LEDC_ON_DUTY);

--- a/esp-client/lib/State/state.cpp
+++ b/esp-client/lib/State/state.cpp
@@ -113,7 +113,14 @@ bool State::isError()
 
 void State::loop()
 {
-	// this->updateLEDs();
+	static byte init_counter = 0;
+	if (this->isInit())
+	{
+		if (init_counter++ > 3)
+		{
+			this->setState(States::INIT, false);
+		}
+	}
 }
 
 void State::updateLEDs()
@@ -123,13 +130,6 @@ void State::updateLEDs()
 		Serial.print("In Error");
 		ledcWrite(R_LEDC_CHANEL, LEDC_ON_DUTY);
 		ledcWrite(B_LEDC_CHANEL, LEDC_OFF_DUTY);
-		digitalWrite(G_LED_PIN, LOW);
-	}
-	else if (this->isInit())
-	{
-		Serial.print("In Init");
-		ledcWrite(R_LEDC_CHANEL, LEDC_OFF_DUTY);
-		ledcWrite(B_LEDC_CHANEL, LEDC_ON_DUTY);
 		digitalWrite(G_LED_PIN, LOW);
 	}
 	else if (this->isOccupied())

--- a/esp-client/lib/State/state.h
+++ b/esp-client/lib/State/state.h
@@ -18,10 +18,10 @@ public:
 	void setupLEDs();
 
 	void setState(States state, bool isActive);
-	bool isInit();
 	void loop();
 
 private:
+	bool isInit();
 	bool isError();
 	bool isCommunicationError();
 	bool isScaleError();

--- a/esp-client/lib/State/state.h
+++ b/esp-client/lib/State/state.h
@@ -15,7 +15,7 @@ enum States
 class State
 {
 public:
-	void setupLEDs();
+	void init();
 
 	void setState(States state, bool isActive);
 	void loop();
@@ -26,6 +26,7 @@ private:
 	bool isCommunicationError();
 	bool isScaleError();
 	bool isOccupied();
+	void setupLEDs();
 	void updateLEDs();
 	char c_currentState;
 };

--- a/esp-client/src/main.cpp
+++ b/esp-client/src/main.cpp
@@ -89,10 +89,7 @@ void loop()
 {
 	if (WiFi.status() != WL_CONNECTED)
 	{
-		if (!state.isInit()) // state unequal Init
-		{
-			state.setState(States::COMMUNICATION_ERR, true);
-		}
+		state.setState(States::COMMUNICATION_ERR, true);
 	}
 	else
 	{
@@ -207,10 +204,7 @@ void reconnect()
 	if (client.connected())
 		return;
 
-	if (!state.isInit())
-	{
-		state.setState(States::COMMUNICATION_ERR, true);
-	}
+	state.setState(States::COMMUNICATION_ERR, true);
 
 	// TODO: Get MAC Address as ID
 	if (client.connect(MAC.c_str(), MQTT_USER, MQTT_PASS, ("/" + MAC + "/online").c_str(), 1, true, "disconnected"))

--- a/esp-client/src/main.cpp
+++ b/esp-client/src/main.cpp
@@ -87,16 +87,6 @@ void setup()
 
 void loop()
 {
-	static byte init_counter = 0;
-	if (state.isInit())
-	{
-		init_counter++;
-		if (init_counter > 3)
-		{
-			state.setState(States::INIT, false);
-		}
-	}
-	// TODO: Optimieren wann welche Status LED blinkt
 	if (WiFi.status() != WL_CONNECTED)
 	{
 		if (!state.isInit()) // state unequal Init

--- a/esp-client/src/main.cpp
+++ b/esp-client/src/main.cpp
@@ -41,8 +41,7 @@ void setup()
 	Serial.begin(115200); // Serial connection to PC
 	delay(100);
 	Serial.println("###################################  STARTUP ################################");
-	state.setupLEDs();
-	state.setState(States::INIT, true);
+	state.init();
 
 #ifdef WIPE			   // if wipe is defined
 	nvs_flash_erase(); // format nvs-partition
@@ -204,8 +203,6 @@ void reconnect()
 	if (client.connected())
 		return;
 
-	state.setState(States::COMMUNICATION_ERR, true);
-
 	// TODO: Get MAC Address as ID
 	if (client.connect(MAC.c_str(), MQTT_USER, MQTT_PASS, ("/" + MAC + "/online").c_str(), 1, true, "disconnected"))
 	{
@@ -217,6 +214,8 @@ void reconnect()
 	}
 	else
 	{
+		state.setState(States::COMMUNICATION_ERR, true);
+
 		Serial.print("failed, rc=");
 		Serial.println(client.state());
 		delay(1000);


### PR DESCRIPTION
Der Init Status wird jetzt in der `state.loop()` nach einiger Zeit automatisch gelöscht. 

Die Priorität von `INIT` wurde erhöht, somit braucht man nicht mehr überprüfen, ob man auf Fehler setzen soll