### PR TITLE
MQTT-Refactoring

### DIFF
--- a/esp-client/lib/Mqtt/MqttUtils.cpp
+++ b/esp-client/lib/Mqtt/MqttUtils.cpp
@@ -87,7 +87,8 @@ void mqttLoop()
 	// if (mqttClient.connect(WiFi.macAddress().c_str(), MQTT_USER, MQTT_PASS))
 	{
 		// Subscribe to all SubTopics
-		mqttClient.subscribe(("/" + WiFi.macAddress() + "/#").c_str());
+		mqttClient.subscribe(("/" + WiFi.macAddress() + "/#").c_str(), 1);
+		mqttClient.subscribe("/server/online", 1);
 
 		// Update last will topic to be connected
 		mqttClient.publish(willTopic.c_str(), "connected", true);

--- a/esp-client/lib/Mqtt/MqttUtils.cpp
+++ b/esp-client/lib/Mqtt/MqttUtils.cpp
@@ -26,13 +26,6 @@ const SubTopic getSubTopic(const char *topic)
 			return i->first;
 	}
 
-	// Check for self published messages
-	for (auto i = PubTopicMap.begin(); i != PubTopicMap.end(); ++i)
-	{
-		if (i->second == topic)
-			return UNDEFINED;
-	}
-
 	// Notify user using serial
 	Serial.print("Received topic '");
 	Serial.print(topic);
@@ -88,10 +81,13 @@ void mqttLoop()
 	// Reconnect to broker if it is not already connected
 	if (mqttClient.connect(WiFi.macAddress().c_str(), MQTT_USER, MQTT_PASS, willTopic, 1, true, "disconnected"))
 	{
-		// Subscribe to all topics that are connected to this device
-		mqttClient.subscribe(("/" + WiFi.macAddress() + "/#").c_str(), 1);
-		// We want to get notified if server online state changes
-		mqttClient.subscribe("/server/online", 1);
+		// Subscribe to all SubTopics
+		for (auto i = SubTopicMap.begin(); i != SubTopicMap.end(); ++i)
+		{
+			Serial.print("Subscribe to: ");
+			Serial.println(i->second);
+			mqttClient.subscribe(i->second);
+		}
 
 		// Update last will topic to be connected
 		mqttClient.publish(willTopic, "connected", true);

--- a/esp-client/lib/Mqtt/MqttUtils.cpp
+++ b/esp-client/lib/Mqtt/MqttUtils.cpp
@@ -1,0 +1,124 @@
+#include "MqttUtils.h"
+
+// Combine enum values with MQTT topics
+std::map<PubTopic, const char *> PubTopicMap{
+	{PubTopic::SCALE_OFFSET, ("/" + WiFi.macAddress() + "/calibration/scaleOffset").c_str()},
+	{PubTopic::SCALE_FACTOR, ("/" + WiFi.macAddress() + "/calibration/scaleValue").c_str()},
+	{PubTopic::WEIGHT_UPDATE, ("/" + WiFi.macAddress() + "/currentWeight").c_str()},
+	{PubTopic::REGISTER_DEVICE, "/devices"}};
+
+// Combine enum values with MQTT topics
+std::map<SubTopic, const char *> SubTopicMap{
+	{SubTopic::SERVER_ONLINE, "/server/online"},
+	{SubTopic::DEVICE_REGISTERED, ("/" + WiFi.macAddress()).c_str()},
+	{SubTopic::COMMAND_CALC_OFFSET, ("/" + WiFi.macAddress() + "/command/CalcOffset").c_str()},
+	{SubTopic::COMMAND_CALC_FACTOR, ("/" + WiFi.macAddress() + "/command/CalibrateScale").c_str()},
+	{SubTopic::COMMAND_APPLY_CALIBRATION, ("/" + WiFi.macAddress() + "/command/ApplyCalibration").c_str()},
+	{SubTopic::COMMAND_CANCEL_CALIBRATION, ("/" + WiFi.macAddress() + "/command/CancelCalibration").c_str()}};
+
+// convert received topic to enum
+const SubTopic getSubTopic(const char *topic)
+{
+	// Check each entry if it is the topic
+	for (auto i = SubTopicMap.begin(); i != SubTopicMap.end(); ++i)
+	{
+		if (i->second == topic)
+			return i->first;
+	}
+
+	// Check for self published messages
+	for (auto i = PubTopicMap.begin(); i != PubTopicMap.end(); ++i)
+	{
+		if (i->second == topic)
+			return UNDEFINED;
+	}
+
+	// Notify user using serial
+	Serial.print("Received topic '");
+	Serial.print(topic);
+	Serial.println("' is yet undefined");
+
+	return SubTopic::UNDEFINED;
+}
+
+// Necessary objects for mqtt communication
+WiFiClient wiFiClient;
+PubSubClient mqttClient(wiFiClient);
+
+// The users callback
+SubCallback subCallback;
+
+void mqttCallback(char *topic, uint8_t *payload, unsigned int length)
+{
+	// Convert message to String
+	String message;
+	for (int i = 0; i < length; i++)
+	{
+		message += (char)message[i];
+	}
+
+	// Print topic and message for debug reasons
+	Serial.print("Message arrived on topic: '");
+	Serial.print(topic);
+	Serial.print("' Message: '");
+	Serial.println(message);
+
+	// Forward callback to the user
+	subCallback(getSubTopic(topic), message);
+}
+
+// Set broker and callback
+void setupMqtt(SubCallback callback)
+{
+	IPAddress mqttServer(SERVER_IP);
+	mqttClient.setServer(mqttServer, 1883);
+	mqttClient.setCallback(mqttCallback);
+}
+
+void mqttLoop()
+{
+	// This function has to be called repeatedly for the broker to work
+	mqttClient.loop();
+
+	if (mqttClient.connected())
+		return;
+
+	const char *willTopic = ("/" + WiFi.macAddress() + "/online").c_str();
+
+	// Reconnect to broker if it is not already connected
+	if (mqttClient.connect(WiFi.macAddress().c_str(), MQTT_USER, MQTT_PASS, willTopic, 1, true, "disconnected"))
+	{
+		// Subscribe to all topics that are connected to this device
+		mqttClient.subscribe(("/" + WiFi.macAddress() + "/#").c_str(), 1);
+		// We want to get notified if server online state changes
+		mqttClient.subscribe("/server/online", 1);
+
+		// Update last will topic to be connected
+		mqttClient.publish(willTopic, "connected", true);
+	}
+	else
+	{
+		// Print connection error
+		Serial.print("failed, rc=");
+		Serial.println(mqttClient.state());
+		delay(1000);
+	}
+}
+
+// TODO: Make this more generic
+void publish(PubTopic topic, String payload, bool retain)
+{
+	const char *topicStr = PubTopicMap.find(topic)->second;
+	switch (topic)
+	{
+		// To register this device we send the server our mac address
+	case PubTopic::REGISTER_DEVICE:
+		mqttClient.publish(topicStr, WiFi.macAddress().c_str());
+		break;
+
+	default:
+		// All other messages will be forwarded
+		mqttClient.publish(topicStr, payload.c_str(), retain);
+		break;
+	}
+}

--- a/esp-client/lib/Mqtt/MqttUtils.cpp
+++ b/esp-client/lib/Mqtt/MqttUtils.cpp
@@ -105,6 +105,15 @@ void mqttLoop()
 void publish(PubTopic topic, String payload, bool retain)
 {
 	const char *topicStr = PubTopicMap.find(topic)->second;
+
+	Serial.print("Published topic '");
+	Serial.print(topicStr);
+	Serial.print("' with payload '");
+	Serial.print(payload.c_str());
+	Serial.print("' ");
+	Serial.print(retain ? "with" : "without");
+	Serial.print(" retain flag");
+
 	switch (topic)
 	{
 		// To register this device we send the server our mac address

--- a/esp-client/lib/Mqtt/MqttUtils.cpp
+++ b/esp-client/lib/Mqtt/MqttUtils.cpp
@@ -5,8 +5,7 @@ const SubTopic getSubTopic(const char *topic)
 {
 	// Notify user using serial
 	Serial.print("Received topic '");
-	Serial.print(topic);
-	Serial.println("' is yet undefined");
+	Serial.println(topic);
 
 	if (strcmp(topic, "/server/online") == 0)
 		return SubTopic::SERVER_ONLINE;

--- a/esp-client/lib/Mqtt/MqttUtils.h
+++ b/esp-client/lib/Mqtt/MqttUtils.h
@@ -1,0 +1,33 @@
+#include <Arduino.h>
+#include <functional>
+#include <map>
+#include <WiFi.h>
+#include <PubSubClient.h>
+
+#include "configuration.h"
+
+// All topic we subscribe to
+enum SubTopic
+{
+	UNDEFINED,
+	SERVER_ONLINE,
+	DEVICE_REGISTERED,
+	COMMAND_CALC_OFFSET,
+	COMMAND_CALC_FACTOR,
+	COMMAND_APPLY_CALIBRATION,
+	COMMAND_CANCEL_CALIBRATION
+};
+// All topics we can publish
+enum PubTopic
+{
+	SCALE_OFFSET,
+	SCALE_FACTOR,
+	WEIGHT_UPDATE,
+	REGISTER_DEVICE
+};
+
+typedef std::function<void(SubTopic, String)> SubCallback;
+
+void mqttLoop();
+void setupMqtt(SubCallback callback);
+void publish(PubTopic topic, String payload = "", bool retain = false);

--- a/esp-client/lib/Mqtt/MqttUtils.h
+++ b/esp-client/lib/Mqtt/MqttUtils.h
@@ -1,6 +1,5 @@
 #include <Arduino.h>
 #include <functional>
-#include <map>
 #include <WiFi.h>
 #include <PubSubClient.h>
 

--- a/esp-client/lib/State/state.cpp
+++ b/esp-client/lib/State/state.cpp
@@ -121,7 +121,7 @@ void State::loop()
 	static byte init_counter = 0;
 	if (this->isInit())
 	{
-		if (init_counter++ > 3)
+		if (init_counter++ > 10)
 		{
 			this->setState(States::INIT, false);
 		}

--- a/esp-client/src/main.cpp
+++ b/esp-client/src/main.cpp
@@ -7,7 +7,6 @@
 #include "Scale.h"
 #include "MqttUtils.h"
 
-IPAddress mqttServer(SERVER_IP);
 State state;
 Scale scale;
 
@@ -41,9 +40,8 @@ void setup()
 
 void loop()
 {
+	mqttLoop();
 	bool wiFiConnected = WiFi.status() == WL_CONNECTED;
-	if (wiFiConnected)
-		mqttLoop();
 
 	state.setState(States::COMMUNICATION_ERR, !wiFiConnected || !isServerOnline || !connectedWithNode);
 
@@ -90,6 +88,8 @@ void callback(SubTopic topic, String message)
 		break;
 	case SubTopic::COMMAND_CANCEL_CALIBRATION:
 		scale.cancelCalibration();
+		break;
+	default:
 		break;
 	}
 }


### PR DESCRIPTION
Habe jetzt mal grundsätzlich den MQTT-Bereich etwas überarbeitet, jetzt kann man im `Callback` mit `switch-case` arbeiten, was das ganze etwas leserlicher macht.
Vielleicht gibt es noch eine Möglichkeit, dass man das in der `MqttUtlils.cpp` etwas schöner bzw. es noch etwas übersichtlicher gestaltet
