### PR TITLE
Erkennen von Wägezellenproblemen und setzen des states umgesetzt

### DIFF
--- a/esp-client/lib/Scale/Scale.cpp
+++ b/esp-client/lib/Scale/Scale.cpp
@@ -145,7 +145,11 @@ bool Scale::weightChanged()
 		Serial.print(this->weight);
 		Serial.println("g");
 
+if(hops <= SCALE_ERROR_HOPS) //to prevent int overflow
+{
 		hops++; //increase counter
+}
+
 	}
 
 	if ((time + SCALE_WAIT_TIME) <= millis() && !printed) // if timer has run out (no weight change in the last x seconds)

--- a/esp-client/lib/Scale/Scale.cpp
+++ b/esp-client/lib/Scale/Scale.cpp
@@ -145,10 +145,10 @@ bool Scale::weightChanged()
 		Serial.print(this->weight);
 		Serial.println("g");
 
-if(hops <= SCALE_ERROR_HOPS) //to prevent int overflow
-{
-		hops++; //increase counter
-}
+		if(hops <= SCALE_ERROR_HOPS) //to prevent int overflow
+		{
+			hops++; //increase counter
+		}
 
 	}
 
@@ -171,13 +171,6 @@ if(hops <= SCALE_ERROR_HOPS) //to prevent int overflow
 
 bool Scale::isScaleError() //reports true when the scale is probably misfunctioning
 {
-	if(hops >= SCALE_ERROR_HOPS)
-	{
-		Serial.println("ScaleError detected");
-		return true;
-	}
-	else
-	{
-		return false;
-	}
+	return (hops >= SCALE_ERROR_HOPS);
+
 }

--- a/esp-client/lib/Scale/Scale.cpp
+++ b/esp-client/lib/Scale/Scale.cpp
@@ -128,7 +128,6 @@ bool Scale::weightChanged()
 	static unsigned long time;
 	static bool printed;
 
-	// FIXME: It does not get detected when no scale is connected
 	if (!this->scale.is_ready()) // quit if scale is not ready
 		return false;
 
@@ -145,15 +144,32 @@ bool Scale::weightChanged()
 		Serial.print("weight change detected: "); // print to serial monitor
 		Serial.print(this->weight);
 		Serial.println("g");
+
+		hops++; //increase counter
 	}
 
 	if ((time + SCALE_WAIT_TIME) <= millis() && !printed) // if timer has run out (no weight change in the last x seconds)
 	{
+		hops = 0; //reset counter
+
 		Serial.print("final weight: "); // print to serial monitor
 		Serial.print(this->weight);
 		Serial.println("g");
 
 		printed = true; //disable MQTT publishing once published
+		return true;
+	}
+	else
+	{
+		return false;
+	}
+}
+
+bool Scale::isScaleError() //reports true when the scale is probably misfunctioning
+{
+	if(hops >= SCALE_ERROR_HOPS)
+	{
+		Serial.println("ScaleError detected");
 		return true;
 	}
 	else

--- a/esp-client/lib/Scale/Scale.h
+++ b/esp-client/lib/Scale/Scale.h
@@ -23,6 +23,9 @@ public:
 	void saveScaleValues();
 	void cancelCalibration();
 
+	//Scale error check
+	bool isScaleError();
+
 #ifdef WIPE
 	void wipeFlash();
 #endif // WIPE
@@ -37,6 +40,8 @@ private:
 
 	float weight;
 	float readWeight();
+
+	int hops;
 };
 
 #endif // SCALE_H

--- a/esp-client/lib/Scale/Scale.h
+++ b/esp-client/lib/Scale/Scale.h
@@ -41,7 +41,7 @@ private:
 	float weight;
 	float readWeight();
 
-	int hops;
+	unsigned int hops;
 };
 
 #endif // SCALE_H

--- a/esp-client/lib/config/configuration.h
+++ b/esp-client/lib/config/configuration.h
@@ -18,6 +18,7 @@
 #define SCALE_CLOCK_PIN 33
 
 #define SCALE_WAIT_TIME 5000 //time in ms how long the scale waits after a weight change to report final weight
+#define SCALE_ERROR_HOPS 50 //number of measurements within which the weight has to settle in; othwise an error will be thrown (high number to not mistakenly throw an error)
 
 // -----------------------  State Settings --------------------------- //
 #define R_LED_PIN 0

--- a/esp-client/src/main.cpp
+++ b/esp-client/src/main.cpp
@@ -52,6 +52,8 @@ void loop()
 		publish(PubTopic::WEIGHT_UPDATE, String(weight, 1), true);
 		state.setState(States::OCCUPIED, weight > 1);
 	}
+
+	state.setState(States::SCALE_ERR, scale.isScaleError()); //true when scale has an error
 	state.loop();
 }
 


### PR DESCRIPTION
- Zählt mit, wie oft sich das Gewicht ändert und setzt zurück auf null wenn eingependelt
- wenn Wägezelle nicht angeschlossen oder ähnlich, dann random Werte -> pendelt sich nicht ein
- wenn mehr als 50 `hops`, dann Fehler